### PR TITLE
Add skill-to-project filtering feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,6 +748,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.1.tgz",
       "integrity": "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -805,6 +806,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -1415,6 +1417,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1477,6 +1480,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1966,6 +1970,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2337,6 +2342,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3000,6 +3006,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3166,6 +3173,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6236,6 +6244,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6331,6 +6340,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6339,6 +6349,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7168,7 +7179,8 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.16.tgz",
       "integrity": "sha512-pONL5awpaQX4LN5eiv7moSiSPd/DLDzKVRJz8Q9PgzmAdd1R4307GQS2ZpfiN7ZmekdQrfhZZiSE5jkLR4WNaA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -7221,6 +7233,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7378,6 +7391,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FaCode, FaLaptopCode, FaGraduationCap, FaCloud, FaDatabase } from 'react-icons/fa'
+import { FaCode, FaLaptopCode, FaGraduationCap, FaCloud, FaDatabase, FaExternalLinkAlt } from 'react-icons/fa'
 import { motion } from 'framer-motion'
 import { 
   fadeInUp, 
@@ -11,10 +11,18 @@ import {
   cardHoverSmall 
 } from '@/utils/animations'
 import siteConfig from '@/config/siteConfig'
+import Link from 'next/link'
+import { projects } from '@/contents/projects'
 
 export default function About() {
   const skillCategories = Object.values(siteConfig.about.skills);
   const hasSkills = skillCategories.some(category => category.include);
+
+  const getProjectCountForSkill = (skill: string): number => {
+    return projects.filter(project => 
+      project.skills?.some(s => s.toLowerCase() === skill.toLowerCase())
+    ).length;
+  };
 
   return (
     <div className="container max-w-7xl mx-auto py-12 relative z-10">
@@ -64,9 +72,24 @@ export default function About() {
               <h3 className="text-xl font-semibold mb-2 dark:text-primary">{siteConfig.about.skills.frontend.name}</h3>
               
               <ul className="text-secondary dark:text-white space-y-2">
-                {siteConfig.about.skills.frontend.skill.map((skill) => (
-                  <li key={skill}>{skill}</li>
-                ))}
+                {siteConfig.about.skills.frontend.skill.map((skill) => {
+                  const projectCount = getProjectCountForSkill(skill);
+                  return (
+                    <li key={skill} className="flex items-center justify-between group">
+                      <span>{skill}</span>
+                      {projectCount > 0 && (
+                        <Link 
+                          href={`/projects?skill=${encodeURIComponent(skill)}`}
+                          className="ml-2 text-primary hover:text-primary/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-sm"
+                          title={`View ${projectCount} project${projectCount !== 1 ? 's' : ''}`}
+                        >
+                          <FaExternalLinkAlt className="h-4 w-4" />
+                          <span className="text-xs">({projectCount})</span>
+                        </Link>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </motion.div>
             )}
@@ -80,9 +103,24 @@ export default function About() {
                 <FaDatabase className="h-8 w-8 text-primary dark:text-white mb-4" />
                 <h3 className="text-xl font-semibold mb-2 dark:text-primary">{siteConfig.about.skills.backend.name}</h3>
                 <ul className="text-secondary dark:text-white space-y-2">
-                  {siteConfig.about.skills.backend.skill.map((skill) => (
-                    <li key={skill}>{skill}</li>
-                  ))}
+                  {siteConfig.about.skills.backend.skill.map((skill) => {
+                    const projectCount = getProjectCountForSkill(skill);
+                    return (
+                      <li key={skill} className="flex items-center justify-between group">
+                        <span>{skill}</span>
+                        {projectCount > 0 && (
+                          <Link 
+                            href={`/projects?skill=${encodeURIComponent(skill)}`}
+                            className="ml-2 text-primary hover:text-primary/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-sm"
+                            title={`View ${projectCount} project${projectCount !== 1 ? 's' : ''}`}
+                          >
+                            <FaExternalLinkAlt className="h-4 w-4" />
+                            <span className="text-xs">({projectCount})</span>
+                          </Link>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </motion.div>
             )}
@@ -96,9 +134,24 @@ export default function About() {
                 <FaCloud className="h-8 w-8 text-primary dark:text-white mb-4" />
                 <h3 className="text-xl font-semibold mb-2 dark:text-primary">{siteConfig.about.skills.cloud.name}</h3>
                 <ul className="text-secondary dark:text-white space-y-2">
-                  {siteConfig.about.skills.cloud.skill.map((skill) => (
-                    <li key={skill}>{skill}</li>
-                  ))}
+                  {siteConfig.about.skills.cloud.skill.map((skill) => {
+                    const projectCount = getProjectCountForSkill(skill);
+                    return (
+                      <li key={skill} className="flex items-center justify-between group">
+                        <span>{skill}</span>
+                        {projectCount > 0 && (
+                          <Link 
+                            href={`/projects?skill=${encodeURIComponent(skill)}`}
+                            className="ml-2 text-primary hover:text-primary/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-sm"
+                            title={`View ${projectCount} project${projectCount !== 1 ? 's' : ''}`}
+                          >
+                            <FaExternalLinkAlt className="h-4 w-4" />
+                            <span className="text-xs">({projectCount})</span>
+                          </Link>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </motion.div>
             )}
@@ -111,9 +164,24 @@ export default function About() {
                 <FaCode className="h-8 w-8 text-primary dark:text-white mb-4" />
                 <h3 className="text-xl font-semibold mb-2 dark:text-primary">{siteConfig.about.skills.ai_security.name}</h3>
                 <ul className="text-secondary dark:text-white space-y-2">
-                  {siteConfig.about.skills.ai_security.skill.map((skill) => (
-                    <li key={skill}>{skill}</li>
-                  ))}
+                  {siteConfig.about.skills.ai_security.skill.map((skill) => {
+                    const projectCount = getProjectCountForSkill(skill);
+                    return (
+                      <li key={skill} className="flex items-center justify-between group">
+                        <span>{skill}</span>
+                        {projectCount > 0 && (
+                          <Link 
+                            href={`/projects?skill=${encodeURIComponent(skill)}`}
+                            className="ml-2 text-primary hover:text-primary/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-sm"
+                            title={`View ${projectCount} project${projectCount !== 1 ? 's' : ''}`}
+                          >
+                            <FaExternalLinkAlt className="h-4 w-4" />
+                            <span className="text-xs">({projectCount})</span>
+                          </Link>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </motion.div>
             )}
@@ -126,9 +194,24 @@ export default function About() {
                 <FaGraduationCap className="h-8 w-8 text-primary dark:text-white mb-4" />
                 <h3 className="text-xl font-semibold mb-2 dark:text-primary">{siteConfig.about.skills.tools.name}</h3>
                 <ul className="text-secondary dark:text-white space-y-2">
-                  {siteConfig.about.skills.tools.skill.map((skill) => (
-                    <li key={skill}>{skill}</li>
-                  ))}
+                  {siteConfig.about.skills.tools.skill.map((skill) => {
+                    const projectCount = getProjectCountForSkill(skill);
+                    return (
+                      <li key={skill} className="flex items-center justify-between group">
+                        <span>{skill}</span>
+                        {projectCount > 0 && (
+                          <Link 
+                            href={`/projects?skill=${encodeURIComponent(skill)}`}
+                            className="ml-2 text-primary hover:text-primary/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-sm"
+                            title={`View ${projectCount} project${projectCount !== 1 ? 's' : ''}`}
+                          >
+                            <FaExternalLinkAlt className="h-4 w-4" />
+                            <span className="text-xs">({projectCount})</span>
+                          </Link>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </motion.div>
             )}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,40 +1,101 @@
-'use client'
+"use client";
 
-import { projects } from '@/contents/projects'
-import  ProjectCard  from '@/components/ProjectCard'
-import { motion } from 'framer-motion'
-import { staggerContainer } from '@/utils/animations'
+import { projects } from "@/contents/projects";
+import ProjectCard from "@/components/ProjectCard";
+import { motion } from "framer-motion";
+import { staggerContainer } from "@/utils/animations";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import Link from "next/link";
 
-export default function Projects() {
+function ProjectsContent() {
+  const searchParams = useSearchParams();
+  const skillFilter = searchParams.get("skill");
+
+  // Filter projects based on skill parameter
+  const filteredProjects = skillFilter
+    ? projects.filter((project) =>
+        project.skills?.some(
+          (skill) => skill.toLowerCase() === skillFilter.toLowerCase()
+        )
+      )
+    : projects;
+
   return (
     <div className="container max-w-7xl mx-auto py-12 relative z-10">
-      <motion.h1 
+      <motion.h1
         className="text-4xl font-bold mb-4 text-center"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        My Projects
+        {skillFilter ? `Projects using ${skillFilter}` : "My Projects"}
       </motion.h1>
-      <motion.p 
-        className="text-lg text-secondary mb-24 text-center"
+      <motion.p
+        className={`text-lg text-secondary text-center ${skillFilter ? 'mb-8' : 'mb-24'}`}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay: 0.2 }}
       >
-        Here are some of my recent projects. Click on the links to view the code or live demo.
+        {skillFilter
+          ? `Showing ${filteredProjects.length} project${
+              filteredProjects.length !== 1 ? "s" : ""
+            } that use ${skillFilter}`
+          : "Here are some of my recent projects. Click on the links to view the code or live demo."}
       </motion.p>
-      
-      <motion.div 
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3  gap-8"
-        variants={staggerContainer}
-        initial="initial"
-        animate="animate"
-      >
-        {projects.map((project, index) => (
-          <ProjectCard key={index} {...project} />
-        ))}
-      </motion.div>
+
+      {skillFilter && (
+        <div className="text-center mb-16">
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 text-primary hover:underline"
+          >
+            ← View all projects
+          </Link>
+        </div>
+      )}
+
+      {filteredProjects.length > 0 ? (
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3  gap-8"
+          variants={staggerContainer}
+          initial="initial"
+          animate="animate"
+        >
+          {filteredProjects.map((project, index) => (
+            <ProjectCard key={index} {...project} />
+          ))}
+        </motion.div>
+      ) : (
+        <motion.div
+          className="text-center py-16"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          <p className="text-lg text-secondary mb-4">
+            No projects found using {skillFilter}
+          </p>
+          <Link href="/projects" className="text-primary hover:underline">
+            View all projects
+          </Link>
+        </motion.div>
+      )}
     </div>
-  )
-} 
+  );
+}
+
+export default function Projects() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container max-w-7xl mx-auto py-12 relative z-10">
+          <h1 className="text-4xl font-bold mb-4 text-center">My Projects</h1>
+          <p className="text-lg text-secondary mb-24 text-center">Loading...</p>
+        </div>
+      }
+    >
+      <ProjectsContent />
+    </Suspense>
+  );
+}

--- a/src/contents/projects.ts
+++ b/src/contents/projects.ts
@@ -6,6 +6,7 @@ export const projects: Project[] = [
     description:
       "Short description of the project. Users can replace this with their own information.",
     technologies: ["React", "Next.js", "API"],
+    skills: ["React / Next.js", "TypeScript", "Node.js", "REST APIs"],
     githubLink: "https://github.com/your-repo",
     demoLink: "https://your-demo-url.com",
     image: '/projects/project-1.jpeg',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface Project {
   title: string;
   description: string;
   technologies: string[];
+  skills?: string[];
   githubLink?: string;
   demoLink?: string;
   image?: string;


### PR DESCRIPTION
Add skill-to-project filtering feature

Enable users to click on skills in the About page to see projects that use that specific skill. 

- Add skills array field to Project type
- Implement URL-based filtering on projects page
- Add clickable skill badges with hover effects
- Display project counts next to relevant skills
- Include "View all projects" navigation link
- Handle empty states when no projects match filter